### PR TITLE
add real execution tracing to debug

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -60,6 +60,7 @@ verbose() {
 debug(){
     if [ $DEBUG == 1 ]; then
         echo Debug: "$@" >&2
+	set -evx
     fi
 }
 


### PR DESCRIPTION
This helped a bit to track down bugs on OS X. 

Not sure if we'd want debug levels for that, i.e.: `-D` only outputs the debug output that has been there until now, `-DD` outputs bashs verbose, execution and environment content as I added in this commit.
