### PR TITLE
Fix delay option

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -48,6 +48,14 @@ TIMEOUT=30
 # trust anchors are stored
 CAPATH=""
 
+# because running external commands like sleep incurs a fork penalty, we
+# first check if it is necessary
+ratelimit() {
+    if [[ $DELAY != "0" ]]; then
+        sleep $DELAY
+    fi
+}
+
 usage() {
     echo -e "usage: $0 [-a|--allciphers] [-b|--benchmark] [--capath directory] [-d|--delay seconds] [-D|--debug] [-j|--json] [-v|--verbose] [-o|--openssl file] [openssl s_client args] <target:port>
     usage: $0 -h|--help
@@ -109,6 +117,7 @@ test_cipher_on_target() {
         else
             cmnd=$sslcommand
         fi
+        ratelimit
         debug echo \"Q\" \| $cmnd $tls_version
         local tmp=$(echo "Q" | $cmnd $tls_version 1>/dev/stdout 2>/dev/null)
         if grep 'OCSP Response Data' <<<"$tmp" >/dev/null; then
@@ -237,7 +246,6 @@ get_cipher_pref() {
         get_cipher_pref "!$pciph:$ciphersuite"
         return 0
     fi
-    sleep $DELAY
 }
 
 display_results_in_terminal() {
@@ -521,7 +529,5 @@ if [ $ALLCIPHERS -gt 0 ]; then
             r="pass"
         fi
         echo "$c $r"|awk '{printf "%-35s %s\n",$1,$2}'
-        debug "Sleeping for $DELAY."
-        sleep $DELAY
     done
 fi

--- a/top1m/testtop1m.sh
+++ b/top1m/testtop1m.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 parallel=10
 max_bg=50
-absolute_max_bg=100
+absolute_max_bg=400
 max_load_avg=50
 
 if [ $(ulimit -u) -lt $((10*absolute_max_bg)) ]; then
@@ -32,7 +32,7 @@ function scan_host() {
     if [ $? -gt 0 ]; then
         return
     fi
-    ../cipherscan -json -servername $1 $2:443 > results/$1@$2
+    ../cipherscan --delay 2 -json -servername $1 $2:443 > results/$1@$2
 }
 
 function scan_host_no_sni() {
@@ -44,7 +44,7 @@ function scan_host_no_sni() {
     if [ $? -gt 0 ]; then
         return
     fi
-    ../cipherscan -json $1:443 > results/$1
+    ../cipherscan --delay 2 -json $1:443 > results/$1
 }
 
 function scan_hostname() {


### PR DESCRIPTION
Because test_cipher_on_target() runs one connection for every protocol, the delays are between testing separate ciphers, not connections.

Fix it to not run sleep at all when the delay is set to 0 (saves forks) and do rate limiting before every connection, not a set of connections.

Increase the timeout for connections (some servers are slow others put us in tarpit when they see many connections in short succession).

Related change to the scanning script.
