### PR TITLE
Make sure that custom openssl gets selected

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -10,7 +10,10 @@
 
 DOBENCHMARK=0
 BENCHMARKITER=30
-OPENSSLBIN="$(dirname $0)/openssl"
+REALPATH=$(dirname $0)
+# make sure this doesn't error out when readlink -f isn't available (OSX)
+readlink -f $0 &>/dev/null && REALPATH=$(dirname $(readlink -f $0))
+OPENSSLBIN="${REALPATH}/openssl"
 
 # test that timeout or gtimeout (darwin) are present
 TIMEOUTBIN="$(which timeout)"


### PR DESCRIPTION
Symlinks are now resolved
This was an issue when a symlink was created for the cipherscan script
Please note that symlinks are only resolved when readlink -f is available
