### PR TITLE
Addition: show which TLS protocols can't be used for testing

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -12,6 +12,9 @@ DOBENCHMARK=0
 BENCHMARKITER=30
 OPENSSLBIN="$(dirname $0)/openssl"
 
+# default string of TLS protocols
+TLSPROTOCOLS="-ssl2 -ssl3 -tls1 -tls1_1 -tls1_2"
+
 # test that timeout or gtimeout (darwin) are present
 TIMEOUTBIN="$(which timeout)"
 if [ "$TIMEOUTBIN" == "" ]; then
@@ -106,6 +109,19 @@ debug(){
         echo Debug: "$@" >&2
 	set -evx
     fi
+}
+
+check_tls_protocols() {
+    tls_protocols=""
+    for supported_protocol in ${TLSPROTOCOLS}; do
+        ${OPENSSLBIN} s_client "${supported_protocol}" 2>&1 | grep -q "unknown option"
+        if [ $? -eq 0 ]; then
+            # always show warning message as it's important to know what won't be tested
+            echo "${supported_protocol} not supported by ${OPENSSLBIN}"
+        else
+            tls_protocols="${tls_protocols} ${supported_protocol}"
+        fi
+    done
 }
 
 c_hash() {
@@ -234,7 +250,7 @@ test_cipher_on_target() {
     pfs=""
     previous_cipher=""
     certificates=""
-    for tls_version in "-ssl2" "-ssl3" "-tls1" "-tls1_1" "-tls1_2"
+    for tls_version in ${tls_protocols}
     do
         # sslv2 client hello doesn't support SNI extension
         # in SSLv3 mode OpenSSL just ignores the setting so it's ok
@@ -694,7 +710,7 @@ fi
 SCLIENTARGS=$(sed -e s,${TEMPTARGET},,<<<"${@}")
 debug "sclientargs: $SCLIENTARGS"
 
-
+check_tls_protocols
 cipherspref=();
 ciphercertificates=()
 results=()


### PR DESCRIPTION
Check which protocols (actually options) are supported by ${OPENSSLBIN}
Always show a message which protocol isn't supported (this could be verbose, but it's crucial to know what will not be tested)
