### PR TITLE
Changed cipher ordering for 'sensitive' servers

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -35,9 +35,10 @@ if [ ! -e "$CACERTS" ]; then
     CACERTS="$(dirname $0)/ca-bundle.crt"
 fi
 
-# RSA ciphers are put at the end to force Google servers to accept ECDSA ciphers
-# (probably a result of a workaround for the bug in Apple implementation of ECDSA)
-CIPHERSUITE="ALL:COMPLEMENTOFALL:+aRSA"
+# RSA ciphers can be placed at the end to force Google servers to accept ECDSA ciphers
+# (probably a result of a workaround for the bug in Apple implementation of ECDSA) :
+#CIPHERSUITE="ALL:COMPLEMENTOFALL:+aRSA"
+CIPHERSUITE="ALL:COMPLEMENTOFALL:aRSA"
 DEBUG=0
 VERBOSE=0
 DELAY=0


### PR DESCRIPTION
Prevents certain servers on choking

I understand if this is somewhat controversial - I have seen servers that choke on 'ALL:+aRSA'  but work perfectly on ' ALL:aRSA', but from what I understood from the comments this ordering has a reason as well...
