### PR TITLE
Added usage print and exit if no options are given

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -596,6 +596,12 @@ test_serverside_ordering() {
     fi
 }
 
+# If no options are given, give usage information and exit (with error code)
+if [ $# -eq 0 ]; then
+   usage;
+   exit 1
+fi
+
 # UNKNOWNOPTIONS=""
 while :
 do


### PR DESCRIPTION
I noticed that if no options are given to cipherscan, then it will attempt to run a scan on <blank>:443 . I figured that if no flags are given, the program should execute the help screen (-h), and exit.
