### PR TITLE
fix silent TypeError on sigalg md5WithRSAEncryption

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -62,7 +62,7 @@ def is_fubar(results):
                 has_wrong_pfs = True
         if 'md5WithRSAEncryption' in conn['sigalg']:
             has_md5_sig = True
-            logging.debug(conn['sigalg']+ ' is a fubar cert signature')
+            logging.debug(conn['sigalg'][0] + ' is a fubar cert signature')
             fubar = True
         if conn['trusted'] == 'False':
             has_untrust_cert = True


### PR DESCRIPTION
conn['sigalg'] is an array, logging.debug(conn['sigalg']) caused silent failure

Test case:
{"target":"redacted:443","utctimestamp":"2015-01-10T02:07:53.0Z","serverside":"False","ciphersuite": [{"cipher":"DHE-RSA-AES256-SHA","protocols":["SSLv3","TLSv1"],"pubkey":["1024"],"sigalg":["md5WithRSAEncryption"],"trusted":"False","ticket_hint":"None","ocsp_stapling":"False","pfs":"DH,1024bits"},{"cipher":"AES256-SHA","protocols":["SSLv3","TLSv1"],"pubkey":["1024"],"sigalg":["md5WithRSAEncryption"],"trusted":"False","ticket_hint":"None","ocsp_stapling":"False","pfs":"None"},{"cipher":"EDH-RSA-DES-CBC3-SHA","protocols":["SSLv3","TLSv1"],"pubkey":["1024"],"sigalg":["md5WithRSAEncryption"],"trusted":"False","ticket_hint":"None","ocsp_stapling":"False","pfs":"DH,1024bits"},{"cipher":"DES-CBC3-SHA","protocols":["SSLv3","TLSv1"],"pubkey":["1024"],"sigalg":["md5WithRSAEncryption"],"trusted":"False","ticket_hint":"None","ocsp_stapling":"False","pfs":"None"}]}