### PR TITLE
Spanish support for bash version check

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -19,7 +19,7 @@ if [ "$(uname -s)" == "Darwin" ]; then
 fi
 
 # cipherscan requires bash4, which doesn't come by default in OSX
-if [ "$(bash --version |grep 'version 4')" == "" ]; then
+if [ "$(bash --version |grep -E 'version 4|versión 4)" == "" ]; then
     echo "Bash version 4 is required to run cipherscan."
     echo "Please upgrade your version of bash (ex: brew install bash)."
     exit 1


### PR DESCRIPTION
Modified the grep to also match for the bash's version output in Spanish.