### PR TITLE
GOST support

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -42,6 +42,11 @@ if [[ "$TIMEOUTOUTPUT" =~ BusyBox ]]; then
     TIMEOUTBIN="$TIMEOUTBIN -t"
 fi
 
+# use custom config file to enable GOST ciphers
+if [[ -e $(dirname $0)/openssl.cnf ]]; then
+    export OPENSSL_CONF="$(dirname $0)/openssl.cnf"
+fi
+
 # find a list of trusted CAs on the local system, or use the provided list
 if [ -z "$CACERTS" ]; then
     for f in /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt; do

--- a/cipherscan
+++ b/cipherscan
@@ -311,7 +311,12 @@ parse_openssl_output() {
         while read data; do
             if [[ $data =~ Signature\ Algorithm ]]; then
                 local match=($data)
-                current_sigalg="${match[2]}"
+                unset match[0]
+                unset match[1]
+                local old_IFS="$IFS"
+                IFS="_"
+                current_sigalg="${match[*]}"
+                IFS="$old_IFS"
             fi
         done <<<"$ossl_out"
     fi

--- a/openssl.cnf
+++ b/openssl.cnf
@@ -1,0 +1,12 @@
+openssl_conf = openssl_def
+
+[openssl_def]
+engines = engine_section
+
+[engine_section]
+gost = gost_section
+
+[gost_section]
+engine_id = gost
+default_algorithms = ALL
+CRYPT_PARAMS = id-Gost28147-89-CryptoPro-A-ParamSet

--- a/top1m/parse_results.py
+++ b/top1m/parse_results.py
@@ -87,6 +87,7 @@ for r,d,flist in os.walk(path):
         tempkeystats = {}
         tempecckeystats = {}
         tempdsakeystats = {}
+        tempgostkeystats = {}
         tempsigstats = {}
         tempticketstats = {}
         tempeccfallback = "unknown"
@@ -101,6 +102,7 @@ for r,d,flist in os.walk(path):
         DES3 = False
         CAMELLIA = False
         RC4 = False
+        GOST89_cipher = False
         """ variables to support handshake simulation for different clients """
         client_RC4_Only={}
         client_compat={}
@@ -124,6 +126,7 @@ for r,d,flist in os.walk(path):
         RSA = False
         ECDH = False
         DH = False
+        GOST2001_kex = False
         SSL2 = False
         SSL3 = False
         TLS1 = False
@@ -220,6 +223,11 @@ for r,d,flist in os.walk(path):
                     ciphertypes += 1
                     name = "y:" + entry['cipher']
                     tempcipherstats[name] = 1
+                elif 'GOST89-GOST89' in entry['cipher']:
+                    GOST89_cipher = True
+                    ciphertypes += 1
+                    name = "y:" + entry['cipher']
+                    tempcipherstats[name] = 1
                 else:
                     ciphertypes += 1
                     name = "z:" + entry['cipher']
@@ -241,6 +249,8 @@ for r,d,flist in os.walk(path):
                     ECDH = True
                 elif 'DH' in entry['cipher']:
                     DH = True
+                elif entry['cipher'].startswith('GOST2001'):
+                    GOST2001_kex = True
                 else:
                     RSA = True
 
@@ -252,6 +262,8 @@ for r,d,flist in os.walk(path):
                     tempdsakeystats[entry['pubkey'][0]] = 1
                 elif 'AECDH' in entry['cipher'] or 'ADH' in entry['cipher']:
                     """ skip """
+                elif 'GOST' in entry['cipher']:
+                    tempgostkeystats[entry['pubkey'][0]] = 1
                 else:
                     tempkeystats[entry['pubkey'][0]] = 1
                     if ECDSA:
@@ -320,6 +332,8 @@ for r,d,flist in os.walk(path):
             keysize['ECDSA ' + s] += 1
         for s in tempdsakeystats:
             keysize['DSA ' + s] += 1
+        for s in tempgostkeystats:
+            keysize['GOST ' + s] += 1
 
         if dualstack:
             dsarsastack += 1
@@ -449,6 +463,8 @@ for r,d,flist in os.walk(path):
             handshakestats['ECDH'] += 1
         if DH:
             handshakestats['DH'] += 1
+        if GOST2001_kex:
+            handshakestats['GOST2001'] += 1
         if RSA:
             handshakestats['RSA'] += 1
 


### PR DESCRIPTION
To enable support for GOST (Russian) ciphers, we need to use a custom `openssl.cnf` file.

To interpret the results we also need to extend the result parser and make sure that the scanner captures the full signature algorithm name.