### PR TITLE
add handling of no ciphers found

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -631,6 +631,10 @@ display_results_in_terminal() {
     local curvesordering
     local different=False
     echo "Target: $TARGET"; echo
+    if [[ ${#cipherspref[*]} -lt 1 ]]; then
+        echo "No ciphers detected! Aborting."
+        exit 1
+    fi
     for cipher in "${cipherspref[@]}"; do
         # get first in array
         pciph=($cipher)


### PR DESCRIPTION
If no ciphers are found, everything else collapses at this point, so simply stop instead of emitting blank/damaged output.