### PR TITLE
enable curves by default

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -137,7 +137,7 @@ TIMEOUT=30
 # trust anchors are stored
 CAPATH=""
 SAVECRT=""
-TEST_CURVES="False"
+TEST_CURVES="True"
 has_curves="False"
 # openssl formated list of curves that will cause server to select ECC suite
 ecc_ciphers=""


### PR DESCRIPTION
Curves scanning should be on by default, since most users of cipherscan ought to use an openssl that supports it (including all OS X users via the included binary). Enabling it by default makes the information available when present, at the cost of a warning for those using an older openssl (which is a warning they should receive in any case, in my opinion.)