### PR TITLE
separate darwin and non-darwin OS autodetection, add NOAUTODETECT support for top1m performance

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -13,8 +13,8 @@ BENCHMARKITER=30
 
 # cipherscan requires bash4, which doesn't come by default in OSX
 if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
-    echo "Bash version 4 is required to run cipherscan."
-    echo "Please upgrade your version of bash (ex: brew install bash)."
+    echo "Bash version 4 is required to run cipherscan." 1>&2
+    echo "Please upgrade your version of bash (ex: brew install bash)." 1>&2
     exit 1
 fi
 

--- a/cipherscan
+++ b/cipherscan
@@ -10,6 +10,14 @@
 
 DOBENCHMARK=0
 BENCHMARKITER=30
+
+# cipherscan requires bash4, which doesn't come by default in OSX
+if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
+    echo "Bash version 4 is required to run cipherscan."
+    echo "Please upgrade your version of bash (ex: brew install bash)."
+    exit 1
+fi
+
 DIRNAMEPATH=$(dirname "$0")
 REALPATH="$DIRNAMEPATH"
 # make sure this doesn't error out when readlink -f isn't available (OSX)
@@ -22,13 +30,6 @@ fi
 OPENSSLBINHELP="$($OPENSSLBIN s_client -help 2>&1)"
 if ! [[ $OPENSSLBINHELP =~ -connect ]]; then
     echo "$OPENSSLBIN s_client doesn't accept the -connect parameter, which is extremely strange; refusing to proceed." 1>&2
-    exit 1
-fi
-
-# cipherscan requires bash4, which doesn't come by default in OSX
-if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
-    echo "Bash version 4 is required to run cipherscan."
-    echo "Please upgrade your version of bash (ex: brew install bash)."
     exit 1
 fi
 

--- a/cipherscan
+++ b/cipherscan
@@ -18,36 +18,85 @@ if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
     exit 1
 fi
 
-DIRNAMEPATH=$(dirname "$0")
-REALPATH="$DIRNAMEPATH"
-# make sure this doesn't error out when readlink -f isn't available (OSX)
-readlink -f "$0" &>/dev/null && REALPATH=$(dirname "$(readlink -f "$0")")
-if [[ "$(uname -s)" == "Darwin" ]]; then
-    OPENSSLBIN="${REALPATH}/openssl-darwin64"
+if [[ -n $NOAUTODETECT ]]; then
+    if ! [[ -f $TIMEOUTBIN && -x $TIMEOUTBIN ]]; then
+        echo "NOAUTODETECT set, but TIMEOUTBIN is not an executable file" 1>&2
+        exit 1
+    fi
+    if ! [[ -f $OPENSSLBIN && -x $OPENSSLBIN ]]; then
+        echo "NOAUTODETECT set, but OPENSSLBIN is not an executable file" 1>&2
+        exit 1
+    fi
 else
-    OPENSSLBIN="${REALPATH}/openssl"
+    case "$(uname -s)" in
+        Darwin)
+            opensslbin_name="openssl-darwin64"
+
+            READLINKBIN=$(which greadlink 2>/dev/null)
+            if [[ -z $READLINKBIN ]]; then
+                echo "greadlink not found. (try: brew install coreutils)" 1>&2
+                exit 1
+            fi
+            TIMEOUTBIN=$(which gtimeout 2>/dev/null)
+            if [[ -z $TIMEOUTBIN ]]; then
+                echo "gtimeout not found. (try: brew install coreutils)" 1>&2
+                exit 1
+            fi
+            ;;
+        *)
+            opensslbin_name="openssl"
+
+            # test that readlink or greadlink (darwin) are present
+            READLINKBIN="$(which readlink)"
+
+            if [[ "$READLINKBIN" == "" ]]; then
+                READLINKBIN="$(which greadlink)"
+                if [[ "$READLINKBIN" == "" ]]; then
+                    echo "neither readlink nor greadlink are present. install coreutils with {apt-get,yum,brew} install coreutils" 1>&2
+                    exit 1
+                fi
+            fi
+
+            # test that timeout or gtimeout (darwin) are present
+            TIMEOUTBIN="$(which timeout)"
+
+            if [[ "$TIMEOUTBIN" == "" ]]; then
+                TIMEOUTBIN="$(which gtimeout)"
+                if [[ "$TIMEOUTBIN" == "" ]]; then
+                    echo "neither timeout nor gtimeout are present. install coreutils with {apt-get,yum,brew} install coreutils" 1>&2
+                    exit 1
+                fi
+            fi
+
+            # Check for busybox, which has different arguments
+            TIMEOUTOUTPUT="$($TIMEOUTBIN --help 2>&1)"
+            if [[ "$TIMEOUTOUTPUT" =~ BusyBox ]]; then
+                TIMEOUTBIN="$TIMEOUTBIN -t"
+            fi
+
+            ;;
+    esac
+fi
+
+DIRNAMEPATH=$(dirname "$0")
+
+if [[ -z $OPENSSLBIN ]]; then
+    readlink_result=$("$READLINKBIN" -f "$0")
+    if [[ -z $readlink_result ]]; then
+        echo "$READLINKBIN -f $0 failed, aborting." 1>&2
+        exit 1
+    fi
+    REALPATH=$(dirname "$readlink_result")
+    if [[ -z $REALPATH ]]; then
+        echo "dirname $REALPATH failed, aborting." 1>&2
+        exit 1
+    fi
+    OPENSSLBIN="${REALPATH}/${opensslbin_name}"
 fi
 OPENSSLBINHELP="$($OPENSSLBIN s_client -help 2>&1)"
 if ! [[ $OPENSSLBINHELP =~ -connect ]]; then
     echo "$OPENSSLBIN s_client doesn't accept the -connect parameter, which is extremely strange; refusing to proceed." 1>&2
     exit 1
-fi
-
-# test that timeout or gtimeout (darwin) are present
-TIMEOUTBIN="$(which timeout)"
-
-if [[ "$TIMEOUTBIN" == "" ]]; then
-    TIMEOUTBIN="$(which gtimeout)"
-    if [[ "$TIMEOUTBIN" == "" ]]; then
-        echo "neither timeout nor gtimeout are present. install coreutils with {apt-get,yum,brew} install coreutils"
-        exit 1
-    fi
-fi
-
-# Check for busybox, which has different arguments
-TIMEOUTOUTPUT="$($TIMEOUTBIN --help 2>&1)"
-if [[ "$TIMEOUTOUTPUT" =~ BusyBox ]]; then
-    TIMEOUTBIN="$TIMEOUTBIN -t"
 fi
 
 # use custom config file to enable GOST ciphers


### PR DESCRIPTION
This patch implements two structural changes.

First, OS-level detection routines are broken out into a case statement.

Darwin doesn't need to test for readlink/timeout nor Busybox, so this
noticeably improves performance over multiple runs on Darwin.

Linux suffers no additional penalty, since we already ran if $(uname)
every time anyways, and continues to use the more complex
timeout/gtimeout/busybox logic at the (preexisting, unaffected) cost to
performance over multiple runs.

Second, if NOAUTODETECT is set, then the script assumes (and verifies)
that you're providing TIMEOUTBIN and OPENSSLBIN values. If both of those
values are executable files, then the script will proceed, else it will
abort. In this scenario, readlink is unnecessary and is thus unused.

The combination of these two changes will improve performance over
multiple runs both on Darwin and when NOAUTODETECT is set for top1m.