### PR TITLE
Replace CACERTS env logic with --cafile parameter.

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -54,7 +54,6 @@ if [[ -e $DIRNAMEPATH/openssl.cnf ]]; then
     export OPENSSL_CONF="$DIRNAMEPATH/openssl.cnf"
 fi
 
-CACERTS=""
 # RSA ciphers are put at the end to force Google servers to accept ECDSA ciphers
 # (probably a result of a workaround for the bug in Apple implementation of ECDSA)
 CIPHERSUITE="ALL:COMPLEMENTOFALL:+aRSA"
@@ -132,7 +131,6 @@ OUTPUTFORMAT="terminal"
 TIMEOUT=30
 # place where to put the found intermediate CA certificates and where
 # trust anchors are stored
-CAPATH=""
 SAVECRT=""
 TEST_CURVES="False"
 has_curves="False"
@@ -1304,6 +1302,8 @@ do
         --cafile)
             CACERTS="$2"
             shift 2
+            # We need to bypass autodetection if this is provided.
+            CACERTS_ARG_SET=1
             ;;
         --capath)
             CAPATH="$2"
@@ -1377,17 +1377,26 @@ if [[ $TEST_CURVES == "True" ]]; then
     fi
 fi
 
-# find a list of trusted CAs on the local system, or use the provided list
-if [[ -z "$CACERTS" ]]; then
+if [[ -z $CACERTS ]] && ! [[ -n $CACERTS_ARG_SET ]]; then
+    # find a list of trusted CAs on the local system, or use the provided list
     for f in /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt; do
         if [[ -e "$f" ]]; then
             CACERTS="$f"
             break
         fi
     done
+    if [[ ! -e "$CACERTS" ]]; then
+        CACERTS="$DIRNAMEPATH/ca-bundle.crt"
+    fi
 fi
-if [[ ! -e "$CACERTS" ]]; then
-    CACERTS="$DIRNAMEPATH/ca-bundle.crt"
+if ! [[ -e $CACERTS && -r $CACERTS ]]; then
+    echo "--cafile $CACERTS is not a readable file, aborting." 1>&2
+    exit 1
+fi
+
+if [[ -n $CAPATH ]] && ! [[ -d $CAPATH ]]; then
+    echo "--capath $CAPATH is not a directory, aborting." 1>&2
+    exit 1
 fi
 
 if [[ $VERBOSE != 0 ]] ; then

--- a/cipherscan
+++ b/cipherscan
@@ -1340,6 +1340,11 @@ do
     esac
 done
 
+if [[ -n $CAPATH && -n $CACERTS ]]; then
+    echo "Both directory and file with CA certificates specified" 1>&2
+    exit 1
+fi
+
 # echo parameters left: $@
 
 TEMPTARGET=$(sed -e 's/^.* //'<<<"${@}")

--- a/cipherscan
+++ b/cipherscan
@@ -54,19 +54,7 @@ if [[ -e $DIRNAMEPATH/openssl.cnf ]]; then
     export OPENSSL_CONF="$DIRNAMEPATH/openssl.cnf"
 fi
 
-# find a list of trusted CAs on the local system, or use the provided list
-if [[ -z "$CACERTS" ]]; then
-    for f in /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt; do
-        if [[ -e "$f" ]]; then
-            CACERTS="$f"
-            break
-        fi
-    done
-fi
-if [[ ! -e "$CACERTS" ]]; then
-    CACERTS="$DIRNAMEPATH/ca-bundle.crt"
-fi
-
+CACERTS=""
 # RSA ciphers are put at the end to force Google servers to accept ECDSA ciphers
 # (probably a result of a workaround for the bug in Apple implementation of ECDSA)
 CIPHERSUITE="ALL:COMPLEMENTOFALL:+aRSA"
@@ -1313,6 +1301,10 @@ do
             DELAY=$2
             shift 2
             ;;
+        --cafile)
+            CACERTS="$2"
+            shift 2
+            ;;
         --capath)
             CAPATH="$2"
             shift 2
@@ -1378,6 +1370,19 @@ if [[ $TEST_CURVES == "True" ]]; then
         echo "curves testing not available with your version of openssl, disabling it"
         TEST_CURVES="False"
     fi
+fi
+
+# find a list of trusted CAs on the local system, or use the provided list
+if [[ -z "$CACERTS" ]]; then
+    for f in /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt; do
+        if [[ -e "$f" ]]; then
+            CACERTS="$f"
+            break
+        fi
+    done
+fi
+if [[ ! -e "$CACERTS" ]]; then
+    CACERTS="$DIRNAMEPATH/ca-bundle.crt"
 fi
 
 if [[ $VERBOSE != 0 ]] ; then


### PR DESCRIPTION
This improves the CACERTS logic to speed performance for top1m, while also replacing the previously-undocumented ```CACERTS=filename.crt``` override with ```--cafile <filename.crt>```, now visible in the help output.

When ```--cafile``` is provided, all autodetection logic is bypassed. Where previously it would replace the provided ```CACERTS``` value with ```ca-bundle.crt``` when the value doesn't exist, it now simply aborts to prevent unexpected "automatic" behaviors when an override is clearly intended.