### PR TITLE
fix coloring of cert key sizes

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -786,7 +786,7 @@ display_results_in_terminal() {
     done|column -t
     echo
     
-    if [[ ($sigalg =~ RSA && $pubkey -gt 2047) || ($sigalg =~ DSA && $pubkey -gt 255) ]]; then
+    if [[ ($sigalg =~ RSA && $pubkey -ge 2047) || ($sigalg =~ ECDSA && $pubkey -gt 255) ]]; then
         pubkey="${c_green}${pubkey}${c_reset}"
     else
         pubkey="${c_red}${pubkey}${c_reset}"


### PR DESCRIPTION
a 2047 bit RSA certificate is just as secure as 2048 bit one (and
known good algorithms can very infrequently provide them when asked for
2048) so accept them too

DSA keys are bad in every case, so always red color them

ECDSA keys are OK above 256 bits