### PR TITLE
Untrusted certificate alert should be red

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -808,7 +808,7 @@ display_results_in_terminal() {
     if [[ $trusted == "True" ]]; then
         trusted="${c_green}trusted${c_reset}"
     else
-        trusted="${c_green}untrusted${c_reset}"
+        trusted="${c_red}untrusted${c_reset}"
     fi
     if [[ $different != "True" ]]; then
         echo -e "Certificate: $trusted, $pubkey bits, $sigalg signature"


### PR DESCRIPTION
Untrusted certificate alert is green when should be red. Fixed here.

![screenshot from 2015-09-23 15-59-56](https://cloud.githubusercontent.com/assets/862690/10055360/2dddf400-620c-11e5-9030-7e56d6b1df3b.png)
