### PR TITLE
properly detect ECDSA certs for size compare

### DIFF
--- a/cipherscan
+++ b/cipherscan
@@ -762,6 +762,7 @@ display_results_in_terminal() {
         fi
         local cipher_data=($cipher)
         if [[ $ctr -eq 1 ]]; then
+            cipher="${cipher_data[1]}"
             pubkey="${cipher_data[2]}"
             sigalg="${cipher_data[3]}"
             trusted="${cipher_data[4]}"
@@ -826,7 +827,7 @@ display_results_in_terminal() {
     done|column -t
     echo
     
-    if [[ ($sigalg =~ RSA && $pubkey -ge 2047) || ($sigalg =~ ECDSA && $pubkey -gt 255) ]]; then
+    if [[ ($sigalg =~ RSA && $pubkey -ge 2047) || ($cipher =~ ECDSA && $pubkey -gt 255) ]]; then
         pubkey="${c_green}${pubkey}${c_reset}"
     else
         pubkey="${c_red}${pubkey}${c_reset}"


### PR DESCRIPTION
since ECDSA certificates during the transition are likely to be
signed using RSA keys, we need to check the cipher rather than the
signature in the certificate to tell if the cert is ECDSA and as such
can have small key sizes