### PR TITLE
changing time of verification for certificate chains

### DIFF
--- a/top1m/process-certificate-statistics.sh
+++ b/top1m/process-certificate-statistics.sh
@@ -40,7 +40,7 @@ if [ ! -x ./parse_CAs ]; then
 fi
 
 echo "Verifying certificate chains from results files"
-./parse_CAs > parsed
+./parse_CAs "$@" > parsed
 echo "Calculating statistics for verified certificate chains"
 python parse_CAs.py > trust_scan
 echo "Done!"


### PR DESCRIPTION
allow to run the analysis of certificate chains later after the
data was collected, allows also for re-analysis of archival data