### PR TITLE
Move CI from Travis to GitHub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: cipherscan
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.10", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: |
+        python -m pip install six
+    - name: Scan
+      run: |
+        ./cipherscan example.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,21 +7,25 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.10", "3.12", "3.14"]
     steps:
-    - uses: actions/checkout@v4
-    - name: Test Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - name: Use Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install
+    - name: Install dependencies
       run: |
-        python -m pip install six
-    - name: Scan
+        pip install six
+    - name: Scan «example.org»
       run: |
         ./cipherscan example.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-dist: trusty
-language: python
-script:
-- ./cipherscan google.com

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CipherScan
 ==========
 
-[![Build Status](https://travis-ci.org/mozilla/cipherscan.svg?branch=master)](https://travis-ci.org/mozilla/cipherscan)
+[![CI](https://github.com/mozilla/cipherscan/actions/workflows/test.yml/badge.svg)](https://github.com/mozilla/cipherscan/actions/workflows/test.yml)
 
 ![cipherscan](https://pbs.twimg.com/media/CPbjvCFW8AAnUK3.png:large)
 

--- a/README.md
+++ b/README.md
@@ -212,20 +212,11 @@ make report
 
 The statically linked binary will be `apps/openssl`.
 
-Contributors
-------------
+Authors
+-------
 
 * Julien Vehent <julien@linuxwall.info> (original author)
 * Hubert Kario <hkario@redhat.com> (co-maintainer)
-* Pepi Zawodsky <git@maclemon.at>
-* Michael Zeltner <m@niij.org>
-* Peter Mosmans <support@go-forward.net>
-* Vincent Riquer <v.riquer@b2f-concept.com>
-* Christian Stadelmann
-* Simon Deziel <simon.deziel@gmail.com>
-* Aaron Zauner <azet@azet.org>
-* Mike <mikedawg@gmail.com>
-* Phil Cohen <phlipper@users.noreply.github.com>
-* Samuel Kleiner <sam@firstbanco.com>
-* Richard Soderberg <https://twitter.com/floatingatoll>
-* Adam Crosby <adamcrosby@users.noreply.github.com>
+* with thanks to all contributors:
+
+<a href="https://github.com/mozilla/cipherscan/graphs/contributors"><img src="https://contrib.rocks/image?repo=mozilla/cipherscan" alt="Contributors generated with https://contrib.rocks"></a>


### PR DESCRIPTION
Removes Travis config and creates a GHA matrix of a handful CPython versions to run cipherscan against example.org for both master pushes as well as PRs open (+manual runs from UI).

Resolves #187

(Also swaps contributor credits for dynamic avatars based on contrib graph, keeping only authors/maintainers for easier maintenance.)